### PR TITLE
Fix issue where AC states would flap

### DIFF
--- a/components/mel_ac/mel_ac.cpp
+++ b/components/mel_ac/mel_ac.cpp
@@ -292,7 +292,7 @@ void MelAirConditioner::do_connect(void) {
   }
 }
 
-bool MelAirConditioner::do_update(void) {
+bool MelAirConditioner::do_control(void) {
   auto &params = this->set_params();
 
   if (!params.is_pending()) {
@@ -364,6 +364,9 @@ bool MelAirConditioner::do_update(void) {
   ESP_LOGV(TAG, "REQ> SET_PARAMS");
   this->conn_.send_command(MEL_COMMAND_FLAGS_SET, payload, sizeof(payload));
 
+  // Force poll restart to pull the latest unit states
+  this->restart_poll(true);
+
   return true;
 }
 
@@ -373,7 +376,7 @@ void MelAirConditioner::do_poll(void) {
     return;
   }
 
-  if (this->do_update()) {
+  if (this->do_control()) {
     return;
   }
 

--- a/components/mel_ac/mel_ac.h
+++ b/components/mel_ac/mel_ac.h
@@ -12,7 +12,7 @@ namespace esphome {
 namespace mel {
 namespace ac {
 
-static const uint32_t MEL_SUPPORTED_BAUD_RATES[] = { 2400, 4800, 9600 };
+static const uint32_t MEL_SUPPORTED_BAUD_RATES[] = {2400, 4800, 9600};
 
 // Temperature Limits
 static const uint8_t MEL_AC_TEMP_MIN = 16;  // Minimum Temperature in Celsius
@@ -324,9 +324,9 @@ class MelAirConditioner : public PollingComponent, public uart::UARTDevice, publ
   void set_connected(bool value) { this->ac_connected_ = value; }
   bool get_connected(void) { return this->ac_connected_; }
 
-  void restart_poll(void) {
+  void restart_poll(bool force = false) {
     const uint32_t now = millis();
-    if ((now - this->ac_poll_timestamp_) > this->ac_poll_refresh_rate_) {
+    if (force || (now - this->ac_poll_timestamp_) > this->ac_poll_refresh_rate_) {
       this->set_poll_flag(MEL_POLL_ALL);
       this->ac_poll_timestamp_ = now;
     }
@@ -345,7 +345,7 @@ class MelAirConditioner : public PollingComponent, public uart::UARTDevice, publ
   void process_response(void);
 
   void do_publish(void);
-  bool do_update(void);
+  bool do_control(void);
 
   void do_connect(void);
   void do_poll(void);


### PR DESCRIPTION
Fix an issue where the AC states would revert back to a previous state in HomeAssistant. Issue was caused by the 'control' update occurring during a poll state, this results in the stale polled state to be published instead of the true latest state.

Solution is to force a poll restart after each 'control' update. This ensures that the next publish will contain the most recent unit states.