### PR TITLE
Improves KDK parameter handling and syncing

### DIFF
--- a/components/kdk/kdk_conn.h
+++ b/components/kdk/kdk_conn.h
@@ -23,7 +23,7 @@ static const uint32_t KDK_RECV_TIMEOUT = 300;  // Message response timeout in ms
 static const uint32_t KDK_SEND_MAX_RETRY = 5;  // Number of retry attempts when a response is not received
 
 static const uint32_t KDK_DEFAULT_POLL_INTERVAL = 5000;
-static const uint32_t KDK_WAIT_SYNC_TIMEOUT = 10000;
+static const uint32_t KDK_WAIT_SYNC_TIMEOUT = 7500;
 
 // KDK Frame Constants
 static const uint8_t KDK_MESSAGE_SYNC = 0x66;   // First byte sent by the device on power up
@@ -220,6 +220,7 @@ class KdkConnectionManager : public PollingComponent, public uart::UARTDevice {
   void clear_message_pending(void) { this->state_.message_pending = false; };
 
   bool is_waiting_response(void) { return this->state_.waiting_response; }
+  void clear_waiting_response(void) { this->state_.waiting_response = false; };
 
   bool is_message_response(uint16_t command);
 
@@ -274,7 +275,7 @@ class KdkConnectionManager : public PollingComponent, public uart::UARTDevice {
 
   bool is_ready(void) { return this->fsm_.state >= KDK_COMM_STATE_INIT_DONE; };
 
-  KdkConnectionManager(){};
+  KdkConnectionManager() {};
 };
 
 }  // namespace kdk

--- a/components/kdk/light/__init__.py
+++ b/components/kdk/light/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_TYPE,
     CONF_COLD_WHITE_COLOR_TEMPERATURE,
     CONF_WARM_WHITE_COLOR_TEMPERATURE,
+    CONF_DEFAULT_TRANSITION_LENGTH,
 )
 
 from .. import (
@@ -30,6 +31,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_TYPE, default="MAIN_LIGHT"): cv.enum(LIGHT_TYPE, upper=True),
             cv.Optional(CONF_COLD_WHITE_COLOR_TEMPERATURE, default="6000K"): cv.color_temperature,
             cv.Optional(CONF_WARM_WHITE_COLOR_TEMPERATURE, default="2700K"): cv.color_temperature,
+            cv.Optional(CONF_DEFAULT_TRANSITION_LENGTH, default="0s"): cv.positive_time_period_milliseconds,
         }
     )
     .extend(KDK_CLIENT_SCHEMA),


### PR DESCRIPTION
Updates parameter handling for KDK communication:

- Clears pending parameter update list to ensure only the latest updates are processed.
- Implements a parameter update map to handle duplicate parameter updates in message 0810, ensuring only unique updates are sent, preventing redundant data transmission.
- Reduces wait sync timeout.
- Add `clear_waiting_response` method.
- Corrects a logging message in `process_message` for clarity.